### PR TITLE
fix bad merge in density plot

### DIFF
--- a/R/densityPlot.R
+++ b/R/densityPlot.R
@@ -52,7 +52,7 @@ densityPlot <- function(ftmsObj, variable, samples=NA, groups=FALSE, title=NA,
   }
   
   # merge e_data and e_meta #  
-  df <- merge(ftmsObj$e_data, ftmsObj$e_meta, by=getMassColName(ftmsObj))
+  df <- merge(ftmsObj$e_data, ftmsObj$e_meta, by=getEDataColName(ftmsObj))
   
   # construct a list with the samples for each plot trace
   trace_subsets <- list()


### PR DESCRIPTION
densityPlot was merging edata/emeta on mass_cname.  I believe we should be merging by the edata_cname, which is the column that is expected in both edata/emeta as per the documentation of `edata_cname` in `?as.peakData`.

This wasn't caught before since the mass_cname was very often the same as edata_cname.