### PR TITLE
fix error checks for inclusion of element_col_names in e_meta

### DIFF
--- a/R/as.ftmsData.R
+++ b/R/as.ftmsData.R
@@ -129,7 +129,7 @@ as.peakData <- function(e_data, f_data, e_meta, edata_cname, fdata_cname, mass_c
   }
   # Check that non-NULL elements in element_col_names are present within e_meta
   for(element in names(element_col_names)){
-    if(!is.null(element_col_names[[element]]) && ! element %in% names(e_meta)){
+    if(!is.null(element_col_names[[element]]) && !element_col_names[[element]] %in% names(e_meta)){
       stop(paste("The following element in 'element_col_names' is not found in e_meta: ", element))
     }
   }


### PR DESCRIPTION
During creation of ftms data with as.peakData, we checked inclusion of the names of `element_col_names` in e_meta column names instead of the values.